### PR TITLE
URLの末尾にスラッシュがないと、ページのマッチングができない問題のFix

### DIFF
--- a/src/coffee/lib/convert.coffee
+++ b/src/coffee/lib/convert.coffee
@@ -44,8 +44,6 @@ f_replace = (str, direction) ->
   # TODO
 
 convert = (path, rules, reverseFlag = false) ->
-  path = path.replace /^\//, ''
-
   if rules
     for rule in rules
       fs = rule.split /\|/


### PR DESCRIPTION
- 正規化のためにスラッシュを外していた
- 途中で、スラッシュの必要不要の自動判別を止めた
- 不要な正規化コードが残っていた

ので、正規化コードを削除。
